### PR TITLE
Feat/pricing tag in product selection

### DIFF
--- a/producer/src/app/(protected)/(footered)/oferta/components/OfferCard.tsx
+++ b/producer/src/app/(protected)/(footered)/oferta/components/OfferCard.tsx
@@ -47,7 +47,7 @@ export default function OfferCard({ offer, onDeleteCard }: OfferCardProps) {
             {new Intl.NumberFormat("pt-BR", {
               style: "currency",
               currency: "BRL",
-            }).format(offer.price)}
+            }).format((offer.price*10)/12)} +20%
           </div>
         </div>
         <div className="flex flex-row justify-end shrink-0 grow-0 basis-16 gap-2 align-start h-full pt-3">

--- a/producer/src/app/(protected)/oferta/components/InputPrice.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputPrice.tsx
@@ -50,13 +50,18 @@ export default function InputPrice({ handleNextStep, price, setPrice }: InputPri
             onSubmit={handleSubmit}
             className="h-full flex flex-col items-stretch justify-between pt-14"
         >
-            <Input
-                onChange={handleChange}
-                className="text-theme-primary text-sm"
-                type="text"
-                value={formatPrice(price * 100)}
-                label="Preço"
-            />
+            <div className="flex flex-col items-stretch justify-start w-full">
+                <Input
+                    onChange={handleChange}
+                    className="text-theme-primary text-sm"
+                    type="text"
+                    value={formatPrice(price * 100)}
+                    label="Preço"
+                />
+                <span className="text-xs text-gray-500 pt-1 pl-2">
+                   Preço + taxa: {formatPrice(price*100 + price*100 * 0.2)}
+                </span>
+            </div>
             <Button className="px-2 py-3 bg-theme-default rounded-lg text-white
             font-semibold border-0">
                 Continuar

--- a/producer/src/app/(protected)/oferta/components/InputPrice.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputPrice.tsx
@@ -37,7 +37,7 @@ export default function InputPrice({ handleNextStep, price, setPrice }: InputPri
         e.preventDefault();
 
         if (!price) {
-            toast.error("Você deve preencher o campo acima!");
+            toast.error("O preço não pode ser vazio. Por favor, insira um valor válido.");
             return;
         }
 

--- a/producer/src/app/(protected)/oferta/components/RenderProducts.tsx
+++ b/producer/src/app/(protected)/oferta/components/RenderProducts.tsx
@@ -144,30 +144,39 @@ export default function RenderProducts({
         </form>
       </div>
       <div className="w-full flex flex-col justify-between h-[calc(100%-3rem)]">
-        <div className="grid grid-cols-2 justify-items-start gap-3 w-full mt-4 p-4 snap-y snap-mandatory overflow-y-auto">
+        <div className="grid grid-cols-2 gap-x-0 justify-start items-start gap-y-3 w-full mt-4 snap-y snap-mandatory overflow-y-auto">
           {Array.isArray(products) && products.length > 0 ? (
             products.map((product, index) => (
               <button
-                className="snap-start flex flex-col items-center rounded-2xl w-full h-[160px] p-2.5 bg-white"
+                className="snap-start flex flex-col items-center rounded-2xl h-[160px] w-[150px] bg-white"
                 key={product.id}
                 ref={products.length === index + 1 ? lastProductRef : null}
                 onClick={() => handleSelectProduct(product)}
               >
-                <div className="relative w-full min-w-[130px] h-[100px] rounded-[10px]">
+                <div className="relative w-full h-full">
                   <Image
-                    className="rounded-[10px]"
+                    className="rounded-t-2xl"
                     loader={imageLoader}
                     src={product.image}
                     alt={`${product.name.toLowerCase()}.jpg`}
                     quality={256}
                     fill={true}
                     sizes="(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 100vw, 256px"
-                    style={{ objectFit: "contain" }}
+                    style={{ objectFit: "cover" }}
                   />
+                  <div className="absolute bottom-0 left-0 right-0 m-auto
+                   w-[50px] h-[20px] bg-slate-gray rounded-t-[10px] flex justify-center items-center">
+                    <span className="text-white text-[11px] leading-[14px] tracking-tight h-5 flex items-center">
+                      {product.pricing === "WEIGHT" ? "kg" : "unid."}
+                    </span>
+                  </div>
                 </div>
-                <span className="pt-2.5 text-base leading-[22px] tracking-tight text-slate-gray">
-                  {product.name}
-                </span>
+                <div className="flex justify-center items-stretch w-full h-[40px] border-t border-[#F6F6F6]">
+                  <span className="flex justify-center items-center w-full
+                  text-[12px] leading-[16px] tracking-tight text-slate-gray h-[inherit]">
+                    {product.name}
+                  </span>
+                </div>
               </button>
             ))
           ) : (

--- a/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
+++ b/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
@@ -55,7 +55,9 @@ export default function ReviewOffer(props: ReviewOfferProps) {
                     </MiniTable.Row>
                     <MiniTable.Row>
                         <MiniTable.HeaderCell>Taxa:</MiniTable.HeaderCell>
-                        <MiniTable.Cell className="col-span-2">20%</MiniTable.Cell>
+                        <MiniTable.Cell className="col-span-2">+20% = {formatPrice((props.price * 100 * 0.2)+props.price * 100)}
+
+                        </MiniTable.Cell>
                     </MiniTable.Row>
                     <MiniTable.Row>
                         <MiniTable.HeaderCell>Descrição:</MiniTable.HeaderCell>

--- a/producer/src/app/(protected)/oferta/editar/page.tsx
+++ b/producer/src/app/(protected)/oferta/editar/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
       setProductId(offerData.product_id);
       setProductName(offerData.product.name);
       setAmount(offerData.product.pricing === "UNIT" ? (offerData.amount) : (offerData.amount / 1000));
-      setPrice(offerData.price);
+      setPrice((offerData.price*10)/12);
       setDescription(offerData.description ? offerData.description : "");
       setPricing(offerData.product.pricing);
       setCurrentStep(1);


### PR DESCRIPTION
Adiciona selo de tipo de precificação dos produtos aos produtos no componente de seleção de produto.

Também arruma mensagem de erro que é retornada no input do preço quando esse é vazio.

Mostra o preço final com a taxa no component the InputPrice e em ReviewOffer. Além disso, retira a taxa ao editar uma oferta e retira a taxa ao mostrar o card da oferta, mostrando o preço inserido inicialmente pelo produtor.