### PR TITLE
Feat/farm name on send bag content

### DIFF
--- a/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
@@ -110,7 +110,7 @@ export default function SendBagMiniTable() {
                   {bagOrder?.orders.map(order => (
                     <div key={order.id} className="flex flex-col mb-5">
                       {`${order.amount}${convertUnit(order.offer.product.pricing)} - ${order.offer.product.name} `}
-                      <span className="text-sm font-bold text-gray-500">{`(${order.offer.catalog.farm.name})`}</span>
+                      <span className="text-sm font-semibold text-theme-primary">{`(${order.offer.catalog.farm.name})`}</span>
                     </div>
                   ))}
                 </div>

--- a/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
@@ -104,13 +104,16 @@ export default function SendBagMiniTable() {
               <span className="w-1/5">Prazo:</span>
               <span className="w-4/5">{getNextSaturdayDate()}</span>
             </div>
-            <div className="text-theme-primary p-3">Conteúdo:</div>
-            <div className="pl-3 pb-3 text-theme-primary">
-              {bagOrder?.orders.map(order => (
-                <div key={order.id}>
-                  {`${order.amount}${convertUnit(order.offer.product.pricing)} - ${order.offer.product.name}`}
+            <div className="flex gap-8 items-start text-theme-primary border-b-[1px] border-theme-background p-3">
+              <span className="w-1/5">Conteúdo:</span>
+                <div className="w-4/5">
+                  {bagOrder?.orders.map(order => (
+                    <div key={order.id} className="flex flex-col mb-5">
+                      {`${order.amount}${convertUnit(order.offer.product.pricing)} - ${order.offer.product.name} `}
+                      <span className="text-sm font-bold text-gray-500">{`(${order.offer.catalog.farm.name})`}</span>
+                    </div>
+                  ))}
                 </div>
-              ))}
             </div>
           </div>
           <div className="w-full h-[10%] flex justify-center items-end">

--- a/shared/src/interfaces/bag-order.ts
+++ b/shared/src/interfaces/bag-order.ts
@@ -32,6 +32,31 @@ export interface BagOrder {
       description: string | null;
       created_at: Date;
       updated_at: Date | null;
+      catalog: {
+        id: string;
+        cycle_id: string;
+        farm: {
+          id: string;
+          name: string;
+          caf: string;
+          active: boolean;
+          tax: number;
+          admin: {
+            id: string;
+            first_name: string;
+            last_name: string;
+            cpf: string;
+            email: string;
+            phone: string;
+            created_at: Date;
+            updated_at: Date | null;
+          };
+          created_at: Date;
+          updated_at: Date | null;
+        };
+        created_at: Date;
+        updated_at: Date | null;
+      };
       product: {
         id: string;
         name: string;


### PR DESCRIPTION
📝 Nome da issue
[CDD] - Implementado o nome da farm em enviar sacola.

🚀 O que foi feito?
Foi adicionado o nome da farm responsável por vender o conteúdo que aparece na tela de enviar sacola como mostrado no tópico abaixo. Além disso, foi feita uma mudança no arquivo de tipagem da bag-order para adicionar o novo dado de catálogo que foi implementado recentemente pelo backend.

📷 Representação visual
![Captura de tela de 2024-09-27 22-45-27](https://github.com/user-attachments/assets/4a98095e-7970-4f57-bbf9-0b05721fc6f6)
