### PR TITLE
Refactor/font import in cdd and footer in consumer

### DIFF
--- a/cdd/src/app/layout.tsx
+++ b/cdd/src/app/layout.tsx
@@ -5,15 +5,7 @@ import { Toaster } from "sonner";
 import { setAppID } from "@shared/next/library/set-app-id";
 import { getAppID } from "@shared/next/library/get-app-id";
 
-import styles from "@shared/app/styles.module.css";
 import { Metadata } from "next";
-
-const poppins = Poppins({
-  weight: ["400", "500", "600", "700"],
-  subsets: ["latin"],
-  display: "swap",
-  preload: true,
-});
 
 export const metadata: Metadata = {
   title: "Painel e-COO | CDD",
@@ -30,7 +22,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${getAppID()} w-screen h-screen ${poppins.className}`}
+        className={`${getAppID()} w-screen h-screen font-poppins`}
       >
         <div className="flex flex-row justify-center w-full h-[inherit]">
           <Toaster richColors position="top-right" />

--- a/consumer/src/app/(footered)/layout.tsx
+++ b/consumer/src/app/(footered)/layout.tsx
@@ -10,7 +10,6 @@ export default function LayoutWithFooter({
       {children}
       <Footer
         appID={"CONSUMER"}
-        bgColor={"#3E5155"}
       />
     </div>
   );


### PR DESCRIPTION
Altera importação da fonte poppins no layout do CDD para usar a importação feita no globals.css com a variável definida no tailwind.

Também remove o parâmetro desnecessário, "bgColor", da instância do componente Footer no layout do app do consumidor.