### PR TITLE
Refactor/update address of cdd storage in producer app

### DIFF
--- a/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
+++ b/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
@@ -48,7 +48,7 @@ export function PendingDeliveries() {
       </p>
       <Button
         type="link"
-        href="https://maps.app.goo.gl/5ZrUfgwhA7evFBXi9"
+        href="https://maps.app.goo.gl/SGVoUf6Vs4LC3UZQ9"
         target="_blank"
         style={{ width: "100%" }}
       >

--- a/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
+++ b/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Tooltip, Button, notification } from "antd";
+import { Tooltip, Button } from "antd";
 
 import { HiOutlineInformationCircle } from "react-icons/hi";
 
@@ -34,10 +34,7 @@ export function PendingDeliveries() {
     navigator.clipboard
       .writeText(address.reduce((acc, curr) => `${acc}\n${curr}`))
       .then(() => {
-        notification.open({
-          message: "Endereço Copiado",
-          description: "Endereço copiado para a área de transferência.",
-        });
+        toast.success("Endereço copiado para a área de transferência.");
         setIsTooltipVisible(false);
       });
   };

--- a/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
+++ b/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
@@ -12,26 +12,34 @@ import { getBoxeCurrent } from "@shared/_actions/boxe/get-boxe-current";
 import { IPendingDeliveries } from "@shared/interfaces/offer";
 import { toast } from "sonner";
 import { useCycleProvider } from "@shared/context/cycle";
-import { useHandleError } from "@shared/hooks/useHandleError"
+import { useHandleError } from "@shared/hooks/useHandleError";
 
 export function PendingDeliveries() {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
-  const [pendingDeliveries, setPendingDeliveries] = useState<IPendingDeliveries[] | undefined>([]);
+  const [pendingDeliveries, setPendingDeliveries] = useState<
+    IPendingDeliveries[] | undefined
+  >([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const { cycle } = useCycleProvider();
 
-  const { handleError } = useHandleError()
+  const { handleError } = useHandleError();
+
+  const address = [
+    "UNIVERSIDADE FEDERAL DO RIO GRANDE - FURG CAMPUS CARREIROS",
+    "Av. Itália, km 8, s/n - Bairro Carreiros CEP: 96203-900 - Rio Grande/RS",
+    "Referência: Antigo prédio do NUDESE, próximo ao prédio do CIDEC e ao lado do prédio da INOVATIO.",
+  ];
 
   const handleCopyAddress = () => {
-    const address =
-      "UNIVERSIDADE FEDERAL DO RIO GRANDE - FURG CAMPUS CARREIROS Av. Itália, km 8, s/n - Bairro Carreiros CEP: 96203-900 - Rio Grande/RS Referência: Antigo prédio do NUDESE, próximo ao prédio do CIDEC e ao lado do prédio da INOVATIO.";
-    navigator.clipboard.writeText(address).then(() => {
-      notification.open({
-        message: "Endereço Copiado",
-        description: "Endereço copiado para a área de transferência.",
+    navigator.clipboard
+      .writeText(address.reduce((acc, curr) => `${acc}\n${curr}`))
+      .then(() => {
+        notification.open({
+          message: "Endereço Copiado",
+          description: "Endereço copiado para a área de transferência.",
+        });
+        setIsTooltipVisible(false);
       });
-      setIsTooltipVisible(false);
-    });
   };
 
   const tooltipContent = (
@@ -39,12 +47,12 @@ export function PendingDeliveries() {
       <p>
         <strong>Endereço do CDD:</strong>
         <br />
-        UNIVERSIDADE FEDERAL DO RIO GRANDE - FURG CAMPUS CARREIROS
-        <br />
-        Av. Itália, km 8, s/n - Bairro Carreiros CEP: 96203-900 - Rio Grande/RS
-        <br />
-        Referência: Antigo prédio do NUDESE, próximo ao prédio do CIDEC e ao
-        lado do prédio da INOVATIO.
+        {address.map((line, index) => (
+          <>
+            <span key={index}>{line}</span>
+            <br />
+          </>
+        ))}
       </p>
       <Button
         type="link"
@@ -78,31 +86,28 @@ export function PendingDeliveries() {
       getBoxeCurrent({ cycle_id: cycle.id })
         .then((response) => {
           if (response.message) {
-            handleError(response.message)
+            handleError(response.message);
           } else {
-            const data: IPendingDeliveries[] = response.data.orders
+            const data: IPendingDeliveries[] = response.data.orders;
 
-            const ordersFiltered = data.filter(item => item.status === 'PENDING');
+            const ordersFiltered = data.filter(
+              (item) => item.status === "PENDING"
+            );
 
             setPendingDeliveries(ordersFiltered);
           }
         })
         .catch(() => {
-          toast.error("Erro desconhecido.")
+          toast.error("Erro desconhecido.");
         })
         .finally(() => {
           setIsLoading(false);
-        })
-    })()
+        });
+    })();
   }, [cycle]);
 
   if (isLoading) {
-    return (
-      <Loader
-        loaderType="component"
-        className="mt-10"
-      />
-    )
+    return <Loader loaderType="component" className="mt-10" />;
   }
 
   return (

--- a/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
+++ b/producer/src/app/(protected)/(footered)/home/components/PendingDeliveries/index.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Tooltip, Button } from "antd";
+import Link from "next/link";
+import { Tooltip } from "antd";
 
 import { HiOutlineInformationCircle } from "react-icons/hi";
 
 import { PendingDeliveriesTable } from "./Table";
 import Loader from "@shared/components/Loader";
+import Button from "@shared/components/ButtonV2";
 
 import { getBoxeCurrent } from "@shared/_actions/boxe/get-boxe-current";
 import { IPendingDeliveries } from "@shared/interfaces/offer";
@@ -40,32 +42,30 @@ export function PendingDeliveries() {
   };
 
   const tooltipContent = (
-    <div>
-      <p>
-        <strong>Endereço do CDD:</strong>
-        <br />
+    <div className="flex flex-col p-2 text-theme-default gap-4">
+      <div className="flex flex-col gap-2 text-xs">
+        <h3 className="text-base font-semibold w-full text-center">
+          Endereço do CDD
+        </h3>
         {address.map((line, index) => (
-          <>
-            <span key={index}>{line}</span>
-            <br />
-          </>
+          <span key={index}>{line}</span>
         ))}
-      </p>
-      <Button
-        type="link"
-        href="https://maps.app.goo.gl/SGVoUf6Vs4LC3UZQ9"
-        target="_blank"
-        style={{ width: "100%" }}
-      >
-        Abrir no Maps
-      </Button>
-      <Button
-        type="primary"
-        style={{ width: "100%" }}
-        onClick={handleCopyAddress}
-      >
-        Copiar endereço
-      </Button>
+      </div>
+      <div className="flex flex-col justify-between items-stretch gap-2 ">
+        <Link href="https://maps.app.goo.gl/SGVoUf6Vs4LC3UZQ9" target="_blank">
+          <Button variant="default" className="w-full h-9 py-0 text-sm mt-0">
+            Abrir no Maps
+          </Button>
+        </Link>
+        <Button
+          variant="light"
+          onClick={handleCopyAddress}
+          className="w-full h-9 py-0 text-sm"
+          border
+        >
+          Copiar endereço
+        </Button>
+      </div>
     </div>
   );
 
@@ -117,7 +117,7 @@ export function PendingDeliveries() {
           <div className="flex gap-2">
             <span className="text-xs text-battleship-gray gap-2 flex">
               CDD - FURG{"   "}
-              <Tooltip title={tooltipContent} trigger="click">
+              <Tooltip title={tooltipContent} trigger="click" color="white">
                 <button className="font-semibold bg-battleship-gray text-white text-xs rounded-md h-4.5 w-24">
                   ver endereço
                 </button>


### PR DESCRIPTION
Esse PR resolve a task "[Produtor] - Alterar o apontamento no google maps do armazém (CDD)":
Link da task: https://app.clickup.com/t/86a5a0dam

Objetivo: alterar o link de referência para o armazém do CDD no aplicativo do produtor.

Foi realizado: 

- Foi feita a substituição do link de https://maps.app.goo.gl/5ZrUfgwhA7evFBXi9 para https://maps.app.goo.gl/SGVoUf6Vs4LC3UZQ9
- Também foi alterada a forma de armazenamento do endereço textual e como é renderizado na página. Antes, o endereço estava duplicado, aparecendo no conteúdo do ToolTip e também na const address que era utilizada pra copiar o endereço para a área de transferência do usuário. Agora, há apenas uma constante que é utilizada em ambos os locais.
- Trocou-se o componente Notification do antd por um toast de sucesso quando o usuário copia o endereço.
- Também optou-se por re-estilizar o ToolTip com o endereço do CDD para um estilo mais próximo dos estilos das aplicações da e-COO, utilizando o ButtonV2 e cores do tema da aplicação.

Antes:
![image](https://github.com/user-attachments/assets/843b9e44-010c-4a14-951f-18e2daecf55a)

Depois:
![image](https://github.com/user-attachments/assets/ab82e794-8635-4406-8ef4-416b88ca0932)
