### PR TITLE
Update/adjust producer info form with new endpoints

### DIFF
--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/ChangePasswordForm.tsx
@@ -1,0 +1,46 @@
+import { forwardRef } from "react";
+import { AiOutlineEye } from "react-icons/ai";
+
+import Input from "@shared/components/Input";
+
+import { useChangePasswordForm } from "./useChangePasswordForm";
+
+interface ChangePasswordFormProps {
+  token: string;
+}
+
+const ChangePasswordForm = forwardRef<HTMLFormElement, ChangePasswordFormProps>(
+  ({ token }, ref) => {
+    const { register, handleSubmit, handleSubmitForm } =
+      useChangePasswordForm(token);
+
+    return (
+      <form
+        ref={ref}
+        onSubmit={handleSubmit(handleSubmitForm)}
+        className="mt-7.5 pb-14 gap-3.5 w-full h-full overflow-y-auto flex flex-col items-center justify-between"
+      >
+        <div className="w-full flex flex-col gap-3.5">
+          <Input
+            register={{ ...register("password") }}
+            placeholder="Digite sua senha"
+            label="Nova senha"
+            icon={<AiOutlineEye />}
+            type="password"
+          />
+          <Input
+            register={{ ...register("confirmPassword") }}
+            placeholder="Digite sua senha"
+            label="Confirmar senha"
+            icon={<AiOutlineEye />}
+            type="password"
+          />
+        </div>
+      </form>
+    );
+  }
+);
+
+ChangePasswordForm.displayName = "ChangePasswordForm";
+
+export default ChangePasswordForm;

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/index.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/index.ts
@@ -1,0 +1,4 @@
+import ChangePasswordForm from "./ChangePasswordForm";
+import { useChangePasswordForm } from "./useChangePasswordForm";
+
+export { ChangePasswordForm, useChangePasswordForm };

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/useChangePasswordForm.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/useChangePasswordForm.ts
@@ -17,7 +17,6 @@ export const useChangePasswordForm = (token: string) => {
   }, [token]);
 
   const handleSubmitForm = async (data: IUser) => {
-    console.log(data);
     Object.keys(data).forEach((key) => {
       if (!data[key as keyof IUser]) {
         delete data[key as keyof IUser];

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/useChangePasswordForm.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangePasswordForm/useChangePasswordForm.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useCookies } from "react-cookie";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { updateUser } from "@shared/_actions/account/update-user";
+import { useHandleError } from "@shared/hooks/useHandleError";
+import { IUser } from "@shared/interfaces/user";
+
+export const useChangePasswordForm = (token: string) => {
+  const { handleError } = useHandleError();
+  const { register, handleSubmit, reset } = useForm<IUser>();
+  const [_, setCookies, removeCookie] = useCookies();
+
+  useEffect(() => {
+    setCookies("token-reset-password", token);
+  }, [token]);
+
+  const handleSubmitForm = async (data: IUser) => {
+    console.log(data);
+    Object.keys(data).forEach((key) => {
+      if (!data[key as keyof IUser]) {
+        delete data[key as keyof IUser];
+      }
+    });
+
+    if (data.password && data.password.length < 8) {
+      toast.error("Senha deve ter pelo menos 8 caracteres.");
+      return;
+    }
+
+    try {
+      const response = await updateUser(data);
+      if (response?.message) {
+        toast.error(response.message);
+        return;
+      }
+
+      removeCookie("token-reset-password");
+      toast.success("Senha atualizada com sucesso!");
+      window.location.href = "/inicio";
+    } catch (error) {
+      handleError(error as string);
+      toast.error("Erro ao atualizar a senha.");
+    }
+  };
+
+  return {
+    register,
+    handleSubmit,
+    handleSubmitForm,
+  };
+};

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/ChangeRegistrationForm.tsx
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/ChangeRegistrationForm.tsx
@@ -1,0 +1,140 @@
+import Image from "next/image";
+import { forwardRef } from "react";
+
+import CustomInput from "@shared/components/CustomInput";
+
+import { useChangeRegistrationForm } from "./useChangeRegistrationForm";
+
+const ChangeRegistrationForm = forwardRef<HTMLFormElement, {}>((props, ref) => {
+  const { register, handleSubmit, handleSubmitForm, errors } =
+    useChangeRegistrationForm();
+
+  return (
+    <form
+      ref={ref}
+      onSubmit={handleSubmit(handleSubmitForm)}
+      className="mt-7.5 pb-14 gap-3.5 w-full h-full overflow-y-auto flex flex-col items-center justify-between"
+    >
+      <>
+        <div className="w-32.5 h-32.5">
+          <Image
+            priority
+            src="/producer.jpeg"
+            alt="User"
+            width={130}
+            height={130}
+            className="rounded-full border border-theme-default object-none object-top aspect-square grayscale cursor-not-allowed"
+          />
+        </div>
+        <div className="w-full flex flex-col items-center justify-center gap-5">
+          <CustomInput
+            register={{ ...register("first_name") }}
+            placeholder="Primeiro nome"
+            label="Nome"
+            type="text"
+            errorMessage={errors.first_name?.message}
+          />
+          <CustomInput
+            register={{ ...register("last_name") }}
+            placeholder="Sobrenome"
+            label="Sobrenome"
+            type="text"
+            errorMessage={errors.last_name?.message}
+          />
+          <CustomInput
+            register={{ ...register("email") }}
+            placeholder="E-mail"
+            label="E-mail"
+            type="text"
+            disabled={false}
+            errorMessage={errors.email?.message}
+          />
+          <CustomInput
+            register={{ ...register("phone") }}
+            placeholder="Celular"
+            label="Celular"
+            type="text"
+            mask="phone"
+            errorMessage={errors.phone?.message}
+          />
+        </div>
+        <hr className="w-37.5 mt-7 mb-2.5 bg-french-gray h-px" />
+        <h3 className="text-xl leading-7.5 font-medium text-theme-home-bg">
+          Informações comerciais
+        </h3>
+        <div className="w-full flex flex-col items-center justify-center gap-5">
+          <CustomInput
+            register={{ ...register("name") }}
+            placeholder="Nome comercial"
+            label="Nome comercial"
+            type="text"
+            errorMessage={errors.name?.message}
+          />
+          <CustomInput
+            register={{ ...register("tally") }}
+            placeholder="Número do Talão"
+            label="Número do Talão"
+            inputMode="numeric"
+            type="text"
+            mask="tally"
+            errorMessage={errors.tally?.message}
+          />
+          <div className="w-full h-full relative flex flex-col text-slate-gray">
+            <label className="text-sm leading-4.75 font-inter font-normal text-theme-primary pb-1.75 flex flex-row items-center justify-start gap-2 tracking-tight-2">
+              Descrição
+            </label>
+            <textarea
+              {...register("description")}
+              maxLength={200}
+              placeholder="Escreva uma breve descrição"
+              className="w-full p-3 border border-theme-primary rounded-lg font-inter font-normal box-border h-50 resize-none"
+            />
+          </div>
+          <div className="relative flex flex-col text-slate-gray w-full">
+            <label className="text-sm leading-4.75 font-inter font-normal text-theme-primary pb-1.75 flex flex-row items-center justify-start gap-2 tracking-tight-2">
+              Selecione até 4 fotos
+            </label>
+            <div className="w-full flex flex-row justify-start items-center flex-wrap gap-3.25">
+              <Image
+                priority
+                src="/producer.jpeg"
+                alt="User"
+                width={130}
+                height={130}
+                className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
+              />
+              <Image
+                priority
+                src="/producer.jpeg"
+                alt="User"
+                width={130}
+                height={130}
+                className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
+              />
+              <Image
+                priority
+                src="/producer.jpeg"
+                alt="User"
+                width={130}
+                height={130}
+                className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
+              />
+              <Image
+                priority
+                src="/producer.jpeg"
+                alt="User"
+                width={130}
+                height={130}
+                className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
+              />
+            </div>
+          </div>
+        </div>
+      </>
+    </form>
+  );
+});
+
+ChangeRegistrationForm.displayName = "ChangeRegistrationForm";
+
+export default ChangeRegistrationForm;

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/index.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/index.ts
@@ -1,0 +1,4 @@
+import ChangeRegistrationForm from "./ChangeRegistrationForm";
+import { useChangeRegistrationForm } from "./useChangeRegistrationForm";
+
+export { ChangeRegistrationForm, useChangeRegistrationForm };

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/useChangeRegistrationForm.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/useChangeRegistrationForm.ts
@@ -53,7 +53,6 @@ export const useChangeRegistrationForm = () => {
   }, []);
 
   const handleSubmitForm = async (data: ChangeRegistrationSchema) => {
-    console.log(data);
     starTransition(async () => {
       const isValid = await trigger();
 
@@ -66,7 +65,6 @@ export const useChangeRegistrationForm = () => {
         delete data[key as keyof ChangeRegistrationSchema];
       }
     });
-    console.log(data);
 
     const farmData: IUpdateFarm = {
       name: data.name,

--- a/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/useChangeRegistrationForm.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/ChangeRegistrationForm/useChangeRegistrationForm.ts
@@ -1,0 +1,108 @@
+import { useEffect, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { fetchUserFarm } from "@producer/app/_actions/account/fetch-user-farm";
+import { updateFarm } from "@producer/app/_actions/account/update-farm";
+import { getUser } from "@shared/_actions/account/get-user";
+import { updateUser } from "@shared/_actions/account/update-user";
+import { useHandleError } from "@shared/hooks/useHandleError";
+import { IUpdateFarm } from "@shared/interfaces/farm";
+import { IUserUpdate } from "@shared/interfaces/user";
+import {
+  ChangeRegistrationSchema,
+  changeRegistrationSchema,
+} from "@shared/schemas/change-registration";
+
+export const useChangeRegistrationForm = () => {
+  const [isPending, starTransition] = useTransition();
+  const { handleError } = useHandleError();
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+    trigger,
+  } = useForm<ChangeRegistrationSchema>({
+    resolver: zodResolver(changeRegistrationSchema),
+    mode: "onChange",
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [farmResponse, userResponse] = await Promise.all([
+          fetchUserFarm(),
+          getUser(),
+        ]);
+
+        if (farmResponse.message || userResponse.message) {
+          handleError(farmResponse.message || userResponse.message);
+          return;
+        }
+
+        const data = { ...farmResponse.data, ...userResponse.data };
+
+        reset(data);
+      } catch (error) {
+        toast.error(error as string);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleSubmitForm = async (data: ChangeRegistrationSchema) => {
+    console.log(data);
+    starTransition(async () => {
+      const isValid = await trigger();
+
+      if (!isValid) {
+        return;
+      }
+    });
+    Object.keys(data).forEach((key) => {
+      if (!data[key as keyof ChangeRegistrationSchema]) {
+        delete data[key as keyof ChangeRegistrationSchema];
+      }
+    });
+    console.log(data);
+
+    const farmData: IUpdateFarm = {
+      name: data.name,
+      tally: data.tally,
+      description: data.description,
+    };
+
+    const userData: IUserUpdate = {
+      first_name: data.first_name,
+      last_name: data.last_name,
+      email: data.email,
+      phone: data.phone as string,
+    };
+
+    try {
+      const [farmResponse, userResponse] = await Promise.all([
+        updateFarm(farmData),
+        updateUser(userData),
+      ]);
+
+      if (farmResponse.message || userResponse.message) {
+        handleError(farmResponse.message || userResponse.message);
+        return;
+      }
+
+      toast.success("Cadastro atualizado com sucesso!");
+    } catch (error) {
+      handleError(error as string);
+      toast.error("Erro ao atualizar o cadastro.");
+    }
+  };
+
+  return {
+    register,
+    handleSubmit,
+    handleSubmitForm,
+    errors,
+  };
+};

--- a/producer/src/app/(protected)/alterar-cadastro/components/index.ts
+++ b/producer/src/app/(protected)/alterar-cadastro/components/index.ts
@@ -1,0 +1,15 @@
+import {
+  ChangePasswordForm,
+  useChangePasswordForm,
+} from "./ChangePasswordForm";
+import {
+  ChangeRegistrationForm,
+  useChangeRegistrationForm,
+} from "./ChangeRegistrationForm";
+
+export {
+  ChangePasswordForm,
+  ChangeRegistrationForm,
+  useChangePasswordForm,
+  useChangeRegistrationForm,
+};

--- a/producer/src/app/(protected)/alterar-cadastro/page.tsx
+++ b/producer/src/app/(protected)/alterar-cadastro/page.tsx
@@ -1,94 +1,36 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
-import { useCookies } from "react-cookie";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
-import { AiOutlineEye } from "react-icons/ai";
-import { toast } from "sonner";
-import { useForm } from "react-hook-form";
-
-import { useHandleError } from "@shared/hooks/useHandleError";
-import { getUser } from "@shared/_actions/account/get-user";
-import { updateUser } from "@shared/_actions/account/update-user";
-
-import Modal from "@shared/components/Modal";
-import Input from "@shared/components/Input";
 import Button from "@shared/components/Button";
-
-import { IUser } from "@shared/interfaces/user";
+import Modal from "@shared/components/Modal";
 import { ModelPage } from "@shared/components/ModelPage";
 
+import { ChangePasswordForm, ChangeRegistrationForm } from "./components";
+
 export default function AlterarCadastro() {
-  const { handleError } = useHandleError();
-  const { register, handleSubmit, reset } = useForm<IUser>();
   const searchParams = useSearchParams();
-  const [_, setCookies, removeCookie] = useCookies();
+  const token = searchParams.get("token") ?? "";
+
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const token = searchParams.get("token");
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const [isFormValid, setIsFormValid] = useState(false);
 
   useEffect(() => {
-    (async () => {
-      if (token) {
-        setCookies("token-reset-password", token);
-        return;
-      }
-
-      await getUser()
-        .then((response) => {
-          if (response.message) {
-            const messageError = response.message;
-            handleError(messageError);
-            return;
-          }
-          reset(response.data);
-        })
-        .catch((error) => {
-          toast.error(error);
-        });
-    })();
-  }, [token]);
-
-  const handleSubmitForm = async (data: IUser) => {
-    Object.keys(data).forEach((key) => {
-      if (!data[key as keyof IUser]) {
-        delete data[key as keyof IUser];
-      }
-    });
-
-    if (data.password && data.password.length < 8) {
-      toast.error("Senha deve ter pelo menos 8 caracteres.");
-      return;
+    console.log(isFormValid);
+    if (formRef.current) {
+      setIsFormValid(formRef.current.checkValidity());
     }
+  });
 
-    if (data.phone && data.phone.replace(/\D/g, "").length < 11) {
-      toast.error("Formato de telefone inválido.");
-      return;
+  const handleModalAction = () => {
+    if (formRef.current) {
+      formRef.current.requestSubmit();
     }
-
-    await updateUser(data)
-      .then((response) => {
-        if (response?.message) {
-          toast.error(response.message);
-          return;
-        }
-
-        if (token) {
-          removeCookie("token-reset-password");
-          toast.success("Senha atualizada com sucesso!");
-          window.location.href = "/inicio";
-          return;
-        }
-
-        toast.success("Cadastro atualizado com sucesso!");
-        window.location.href = "/";
-      })
-      .catch((error) => {
-        toast.error(error);
-      });
   };
 
   return (
@@ -113,7 +55,7 @@ export default function AlterarCadastro() {
             titleCloseModal="Cancelar"
             titleConfirmModal="Confirmar"
             titleOpenModal="Salvar"
-            modalAction={handleSubmit(handleSubmitForm)}
+            modalAction={handleModalAction}
             bgOpenModal="#2F4A4D"
             bgConfirmModal="#2F4A4D"
             bgCloseModal="bg-gray-100"
@@ -123,6 +65,7 @@ export default function AlterarCadastro() {
               <Button
                 className="w-full h-full rounded-lg bg-theme-default font-semibold text-white"
                 title="Salvar"
+                disabled={!isFormValid}
                 onClick={() => setIsModalOpen(true)}
               >
                 Salvar
@@ -132,138 +75,8 @@ export default function AlterarCadastro() {
         </div>
       }
     >
-      <form className="mt-7.5 pb-14 gap-3.5 w-full h-full overflow-y-auto flex flex-col items-center justify-between">
-        {!token && (
-          <>
-            <div className="w-32.5 h-32.5">
-              <Image
-                priority
-                src="/producer.jpeg"
-                alt="User"
-                width={130}
-                height={130}
-                className="rounded-full border border-theme-default object-none object-top aspect-square grayscale cursor-not-allowed"
-              />
-            </div>
-            <div className="w-full flex flex-col items-center justify-center gap-5">
-              <Input
-                register={{ ...register("first_name") }}
-                placeholder="Primeiro nome"
-                label="Nome"
-                type="text"
-              />
-              <Input
-                register={{ ...register("last_name") }}
-                placeholder="Sobrenome"
-                label="Sobrenome"
-                type="text"
-              />
-              <Input
-                register={{ ...register("email") }}
-                placeholder="E-mail"
-                label="E-mail"
-                type="email"
-                className="cursor-not-allowed text-gray-400"
-                disabled={true}
-              />
-              <Input
-                register={{ ...register("phone") }}
-                placeholder="Celular"
-                label="Celular"
-                type="text"
-              />
-            </div>
-            <hr className="w-37.5 mt-7 mb-2.5 bg-french-gray h-px" />
-            <h3 className="text-xl leading-7.5 font-medium text-theme-home-bg">
-              Informações comerciais
-            </h3>
-            <div className="w-full flex flex-col items-center justify-center gap-5">
-              <Input
-                placeholder="Nome comercial"
-                label="Nome comercial"
-                type="text"
-                disabled
-                className="cursor-not-allowed text-gray-400"
-              />
-              <Input
-                placeholder="Número do Talão"
-                label="Número do Talão"
-                type="text"
-                disabled
-                className="cursor-not-allowed text-gray-400"
-              />
-              <div className="w-full h-full relative flex flex-col text-slate-gray">
-                <label className="text-sm leading-4.75 font-inter font-normal text-theme-primary pb-1.75 flex flex-row items-center justify-start gap-2 tracking-tight-2">
-                  Descrição
-                </label>
-                <textarea
-                  maxLength={200}
-                  value="Elit ipsum deserunt elit exercitation voluptate deserunt quis sunt proident. Est adipisicing proident cillum ad. Ad in sint elit consectetur duis voluptate fugiat. In ex cillum et ipsum magna sint cillum eiusmod non occaecat minim veniam adipisicing. Aliqua ullamco magna labore ex quis voluptate ea occaecat."
-                  className="w-full p-3 border border-theme-primary rounded-lg font-inter font-normal box-border h-56 cursor-not-allowed text-gray-400 resize-none"
-                  disabled
-                />
-              </div>
-              <div className="relative flex flex-col text-slate-gray w-full">
-                <label className="text-sm leading-4.75 font-inter font-normal text-theme-primary pb-1.75 flex flex-row items-center justify-start gap-2 tracking-tight-2">
-                  Selecione até 4 fotos
-                </label>
-                <div className="w-full flex flex-row justify-start items-center flex-wrap gap-3.25">
-                  <Image
-                    priority
-                    src="/producer.jpeg"
-                    alt="User"
-                    width={130}
-                    height={130}
-                    className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
-                  />
-                  <Image
-                    priority
-                    src="/producer.jpeg"
-                    alt="User"
-                    width={130}
-                    height={130}
-                    className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
-                  />
-                  <Image
-                    priority
-                    src="/producer.jpeg"
-                    alt="User"
-                    width={130}
-                    height={130}
-                    className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
-                  />
-                  <Image
-                    priority
-                    src="/producer.jpeg"
-                    alt="User"
-                    width={130}
-                    height={130}
-                    className="rounded-lg w-18 border border-theme-default object-contain object-top aspect-square grayscale cursor-not-allowed"
-                  />
-                </div>
-              </div>
-            </div>
-          </>
-        )}
-        {token && (
-          <div className="w-full flex flex-col gap-3.5">
-            <Input
-              register={{ ...register("password") }}
-              placeholder="Digite sua senha"
-              label="Nova senha"
-              icon={<AiOutlineEye />}
-              type="password"
-            />
-            <Input
-              register={{ ...register("confirmPassword") }}
-              placeholder="Digite sua senha"
-              label="Confirmar senha"
-              icon={<AiOutlineEye />}
-              type="password"
-            />
-          </div>
-        )}
-      </form>
+      {token && <ChangePasswordForm token={token} ref={formRef} />}
+      {!token && <ChangeRegistrationForm ref={formRef} />}
     </ModelPage>
   );
 }

--- a/producer/src/app/(protected)/alterar-cadastro/page.tsx
+++ b/producer/src/app/(protected)/alterar-cadastro/page.tsx
@@ -21,7 +21,6 @@ export default function AlterarCadastro() {
   const [isFormValid, setIsFormValid] = useState(false);
 
   useEffect(() => {
-    console.log(isFormValid);
     if (formRef.current) {
       setIsFormValid(formRef.current.checkValidity());
     }

--- a/producer/src/app/_actions/account/fetch-user-farm.ts
+++ b/producer/src/app/_actions/account/fetch-user-farm.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import ApiService from "@shared/service/index";
+
+export async function fetchUserFarm() {
+  const response = ApiService.GET({
+    url: "/farms/own",
+  });
+
+  return response;
+}

--- a/producer/src/app/_actions/account/update-farm.ts
+++ b/producer/src/app/_actions/account/update-farm.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { IUpdateFarm } from "@shared/interfaces/farm";
+import ApiService from "@shared/service/index";
+
+export async function updateFarm(data: IUpdateFarm) {
+  const response = ApiService.PATCH({
+    url: "/farms",
+    data,
+  });
+
+  return response;
+}

--- a/shared/src/_actions/account/update-user.ts
+++ b/shared/src/_actions/account/update-user.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { IUserUpdate } from "@shared/interfaces/user";
 import ApiService from "@shared/service/index";
-import { IUser } from "@shared/interfaces/user";
 
-export async function updateUser(data: IUser) {
+export async function updateUser(data: IUserUpdate) {
   const response = ApiService.PATCH({
     url: "/users",
     data,

--- a/shared/src/components/CustomInput.tsx
+++ b/shared/src/components/CustomInput.tsx
@@ -3,13 +3,15 @@ import { UseFormRegisterReturn } from "react-hook-form";
 import { AiFillEye, AiFillEyeInvisible } from "react-icons/ai";
 
 import { Masks } from "@shared/types/register";
-import { maskCellphone, maskCPF } from "@shared/utils/index";
+import { maskCellphone, maskCPF, maskTally } from "@shared/utils/index";
+
 import InfoModal from "./InfoModal";
 
 interface CustomInputProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   errorMessage?: string;
   register: UseFormRegisterReturn;
+  type?: string;
   mask?: Masks;
 }
 
@@ -27,6 +29,7 @@ export default function CustomInput({
   const masksActions: Record<Masks, (value: string) => string> = {
     phone: (value: string) => maskCellphone(value),
     cpf: (value: string) => maskCPF(value),
+    tally: (value: string) => maskTally(value),
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/shared/src/interfaces/farm.ts
+++ b/shared/src/interfaces/farm.ts
@@ -16,6 +16,7 @@ export interface IFarm {
   tally: string;
   active: boolean;
   tax: number;
+  description?: string;
   admin: IAdmin;
   created_at: Date;
   updated_at: Date | null;
@@ -28,4 +29,10 @@ export interface IFarmOrders {
   created_at: Date;
   updated_at: Date | null;
   orders: IOrder[];
+}
+
+export interface IUpdateFarm {
+  name: string;
+  tally: string;
+  description?: string;
 }

--- a/shared/src/interfaces/user.ts
+++ b/shared/src/interfaces/user.ts
@@ -13,12 +13,12 @@ export interface IUser {
 }
 
 export interface IUserUpdate {
-  first_name: string;
-  last_name: string;
-  phone: string;
-  email: string;
-  password: string;
-  confirmPassword: string;
+  first_name?: string;
+  last_name?: string;
+  phone?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
 }
 
 export interface IAdmin {

--- a/shared/src/schemas/change-registration/index.ts
+++ b/shared/src/schemas/change-registration/index.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { validateCellphone, validateTally } from "@shared/utils";
+
+export const changeRegistrationSchema = z.object({
+  first_name: z.string().min(1, { message: "Nome obrigatório" }),
+  last_name: z.string().min(1, { message: "Sobrenome obrigatório" }),
+  email: z
+    .string()
+    .min(1, { message: "Email obrigatório" })
+    .email({ message: "Email inválido" }),
+  phone: z
+    .string()
+    .min(1, { message: "Celular obrigatório" })
+    .max(15)
+    .refine((value) => validateCellphone(value), {
+      message: "Celular inválido.",
+    })
+    .optional(),
+  name: z.string().min(1, { message: "Nome obrigatório" }),
+  tally: z
+    .string()
+    .min(1, { message: "Número do talão é obrigatório" })
+    .refine((value) => validateTally(value), {
+      message: "Número do talão inválido.",
+    }),
+  description: z.string().max(200).optional(),
+});
+
+export type ChangeRegistrationSchema = z.infer<typeof changeRegistrationSchema>;

--- a/shared/src/types/register/index.ts
+++ b/shared/src/types/register/index.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
-import { firstStepRegisterSchema, secondStepRegisterSchema, fifthStepRegisterSchema } from "@shared/schemas/register";
 
-export type FirstStepRegisterSchema = z.infer<typeof firstStepRegisterSchema>
+import {
+  fifthStepRegisterSchema,
+  firstStepRegisterSchema,
+  secondStepRegisterSchema,
+} from "@shared/schemas/register";
 
-export type SecondStepRegisterSchema = z.infer<typeof secondStepRegisterSchema>
+export type FirstStepRegisterSchema = z.infer<typeof firstStepRegisterSchema>;
 
-export type FifthStepRegisterSchema = z.infer<typeof fifthStepRegisterSchema>
+export type SecondStepRegisterSchema = z.infer<typeof secondStepRegisterSchema>;
 
-export type Roles = "USER" | "PRODUCER"
+export type FifthStepRegisterSchema = z.infer<typeof fifthStepRegisterSchema>;
 
-export type Masks = 'phone' | 'cpf'
+export type Roles = "USER" | "PRODUCER";
+
+export type Masks = "phone" | "cpf" | "tally";

--- a/shared/src/utils/index.ts
+++ b/shared/src/utils/index.ts
@@ -1,19 +1,23 @@
+import { getNextSaturdayDate } from "./get-next-saturday-date";
+import { getWeekDays } from "./get-week-days";
 import { maskCPF } from "./mask-cpf";
+import { maskDate } from "./mask-date";
 import { maskCellphone } from "./mask-phone";
+import { maskTally } from "./mask-tally";
 import { parseCookies } from "./parse-cookies";
 import { validateCellphone } from "./validate-cellphone";
 import { validateCPF } from "./validate-cpf";
-import { getWeekDays } from "./get-week-days"
-import { maskDate } from "./mask-date";
-import { getNextSaturdayDate } from "./get-next-saturday-date";
+import { validateTally } from "./validate-tally";
 
 export {
-  maskCPF,
-  maskCellphone,
-  validateCPF,
-  validateCellphone,
-  parseCookies,
+  getNextSaturdayDate,
   getWeekDays,
+  maskCellphone,
+  maskCPF,
   maskDate,
-  getNextSaturdayDate
+  maskTally,
+  parseCookies,
+  validateCellphone,
+  validateCPF,
+  validateTally,
 };

--- a/shared/src/utils/mask-tally.ts
+++ b/shared/src/utils/mask-tally.ts
@@ -1,0 +1,4 @@
+export function maskTally(value: string) {
+  if (!value) return "";
+  return value.replace(/\D/g, "");
+}

--- a/shared/src/utils/validate-tally.ts
+++ b/shared/src/utils/validate-tally.ts
@@ -1,0 +1,6 @@
+export function validateTally(value: string) {
+  // has to be a number type integer
+  const tallyRegex = /^\d+$/;
+
+  return tallyRegex.test(value);
+}


### PR DESCRIPTION
Esse PR é uma continuação da task "[Produtor] - Implementar nova tela de perfil do produtor.", que está em andamento e dá sequência ao PR https://github.com/eCOO-FURG/apps/pull/139

Nesse PR foi refatorada a página "/alterar-cadastro", que acomoda ambos o perfil do produtor e o formulário de alteração de senha. Sendo assim, a refatoração consistiu em separar os formulários em seus próprios componentes especializados.

Tendo em vista a criação de novas rotas para receber e alterar as informações de uma farm, foram criadas as actions no formato da ApiService para fazer a comunicação com o backend.

Agora é possível:

- Receber as informações comerciais da farm, sendo elas: nome, número do talão e a descrição
- Alterar nome, número do talão e descrição

Entretanto, ainda falta, da parte do backend, a criação das rotas para lidar com as imagens do produtor. Desse modo, a task ficará bloqueada novamente e deverá ser continuada posteriormente, quando as rotas estiverem prontas.