### PR TITLE
feat: added new status on bags and bug fixes

### DIFF
--- a/admin/src/_actions/bags/update-bag-by-id.ts
+++ b/admin/src/_actions/bags/update-bag-by-id.ts
@@ -7,7 +7,7 @@ interface UpdateBagByIdRequest {
   data: {
     status?:
       | "PENDING"
-      | "SEPARATED"
+      | "MOUNTED"
       | "DISPATCHED"
       | "RECEIVED"
       | "CANCELLED"

--- a/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/enviar-sacola/[bag_id]/components/SendBagMiniTable.tsx
@@ -72,12 +72,12 @@ export default function SendBagMiniTable() {
           <HeaderDetail
             id={bag.id}
             status={
-              currentStatus === "SEPARATED"
+              currentStatus === "MOUNTED"
                 ? convertStatus(bag.status)?.name
                 : undefined
             }
             selectStatus={
-              currentStatus !== "SEPARATED" ? (
+              currentStatus !== "MOUNTED" ? (
                 <div className="w-[110px]">
                   <SelectInput
                     placeholder="Selecione o status"
@@ -101,7 +101,7 @@ export default function SendBagMiniTable() {
           />
           <TablePaginationControl />
           <div className="w-full h-[15%] flex justify-center items-end">
-            {bag.status === "SEPARATED" ? (
+            {bag.status === "MOUNTED" ? (
               <Modal
                 titleOpenModal="Marcar como enviada"
                 titleContentModal="Você tem certeza?"

--- a/cdd/src/app/(protected)/(footered)/enviar-sacola/components/SendBagTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/enviar-sacola/components/SendBagTable.tsx
@@ -21,8 +21,8 @@ type FilterStatus = {
 };
 
 const statuses: FilterStatus[] = [
-  { name: "todas", key: ["SEPARATED", "DISPATCHED", "RECEIVED", "DEFERRED"] },
-  { name: "separadas", key: ["SEPARATED"] },
+  { name: "todas", key: ["MOUNTED", "DISPATCHED", "RECEIVED", "DEFERRED"] },
+  { name: "separadas", key: ["MOUNTED"] },
   { name: "enviadas", key: ["DISPATCHED"] },
   { name: "entregues", key: ["RECEIVED"] },
   { name: "retornadas", key: ["DEFERRED"] },
@@ -136,8 +136,8 @@ export default function SendBagTable() {
                   className: "items-center justify-center w-full",
                   render: (row: BagDTO) =>
                     getStatus({
-                      type: "montar",
-                      status: row.status as BagStatus["build"],
+                      type: "enviar",
+                      status: row.status as BagStatus["send"],
                     }),
                 },
               ]}

--- a/cdd/src/app/(protected)/(footered)/montar-sacola/[bag_id]/components/BagMiniTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/montar-sacola/[bag_id]/components/BagMiniTable.tsx
@@ -32,12 +32,12 @@ export default function BagMiniTable() {
 
   const handleStatusBag = (bag_id: string, status: BagStatus["build"]) => {
     const statusConfig = {
-      PENDING: {
-        nextStatus: "SEPARATED",
+      VERIFIED: {
+        nextStatus: "MOUNTED",
         successMessage: "Sacola preparada com sucesso!",
       },
-      SEPARATED: {
-        nextStatus: "PENDING",
+      MOUNTED: {
+        nextStatus: "VERIFIED",
         successMessage: "A sacola foi alterada com sucesso!",
       },
     };
@@ -77,7 +77,7 @@ export default function BagMiniTable() {
           />
           <TablePaginationControl />
           <div className="w-full h-[15%] flex justify-center items-end">
-            {bag?.status === "PENDING" ? (
+            {bag?.status === "VERIFIED" ? (
               <Modal
                 titleContentModal="Você tem certeza?"
                 contentModal="Ao marcar a sacola como pronta, o cliente será notificado."
@@ -88,7 +88,7 @@ export default function BagMiniTable() {
                 bgConfirmModal="#00735E"
                 bgCloseModal="#EEF1F4"
                 modalAction={() => {
-                  handleStatusBag(bag_id as string, "PENDING");
+                  handleStatusBag(bag_id as string, "VERIFIED");
                 }}
               />
             ) : (
@@ -102,7 +102,7 @@ export default function BagMiniTable() {
                 bgConfirmModal="#FF7070"
                 bgCloseModal="#EEF1F4"
                 modalAction={() => {
-                  handleStatusBag(bag_id as string, "SEPARATED");
+                  handleStatusBag(bag_id as string, "MOUNTED");
                 }}
               />
             )}

--- a/cdd/src/app/(protected)/(footered)/montar-sacola/components/BagsTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/montar-sacola/components/BagsTable.tsx
@@ -22,9 +22,9 @@ type FilterStatus = {
 };
 
 const statuses: FilterStatus[] = [
-  { name: "todas", key: ["PENDING", "SEPARATED"] },
-  { name: "pendentes", key: ["PENDING"] },
-  { name: "separadas", key: ["SEPARATED"] },
+  { name: "todas", key: ["VERIFIED", "MOUNTED"] },
+  { name: "pendentes", key: ["VERIFIED"] },
+  { name: "separadas", key: ["MOUNTED"] },
 ];
 
 export default function BagsTable() {

--- a/cdd/src/app/_actions/bags/GET/list-current-bags.ts
+++ b/cdd/src/app/_actions/bags/GET/list-current-bags.ts
@@ -4,7 +4,8 @@ import ApiService from "@shared/service";
 
 type BagStatus =
   | "PENDING"
-  | "SEPARATED"
+  | "VERIFIED"
+  | "MOUNTED"
   | "DISPATCHED"
   | "RECEIVED"
   | "DEFERRED"

--- a/cdd/src/app/_actions/bags/PATCH/handle-bag.ts
+++ b/cdd/src/app/_actions/bags/PATCH/handle-bag.ts
@@ -4,7 +4,7 @@ import ApiService from "@shared/service";
 
 export interface HandleBagRequest {
   bag_id: string;
-  status: "PENDING" | "SEPARATED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
+  status: "PENDING" | "VERIFIED" | "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
 }
 
 export async function handleBag({ bag_id, status }: HandleBagRequest) {

--- a/shared/src/hooks/useGetStatus.tsx
+++ b/shared/src/hooks/useGetStatus.tsx
@@ -9,15 +9,15 @@ type GetStatusType = "oferta" | "montar" | "enviar" | "farm";
 
 export type OfertaStatus = Array<"PENDING" | "CANCELLED" | "VERIFIED">;
 type FarmStatus = "ACTIVE" | "INACTIVE" | "PENDING";
-export type MontarStatus = Array<"PENDING" | "SEPARATED">;
+export type MontarStatus = Array<"VERIFIED" | "MOUNTED">;
 export type EnviarStatus = Array<
-  "SEPARATED" | "DISPATCHED" | "RECEIVED" | "DEFERRED"
+  "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED"
 >;
 
 export type StatusMap = {
   oferta: "PENDING" | "CANCELLED" | "VERIFIED";
-  montar: "PENDING" | "SEPARATED";
-  enviar: "SEPARATED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
+  montar: "VERIFIED" | "MOUNTED";
+  enviar: "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
   farm: FarmStatus;
 };
 
@@ -54,17 +54,17 @@ export function useGetStatus() {
       },
     },
     montar: {
-      PENDING: {
+      VERIFIED: {
         content: <HiDotsHorizontal size={10} color="white" />,
         color: "bg-walnut-brown",
       },
-      SEPARATED: {
+      MOUNTED: {
         content: <FaCheck className="p-1" color="white" />,
         color: "bg-rain-forest",
       },
     },
     enviar: {
-      SEPARATED: {
+      MOUNTED: {
         content: <FaExclamation size={10} color="white" />,
         color: "bg-battleship-gray",
       },

--- a/shared/src/interfaces/dtos/bag-dto.ts
+++ b/shared/src/interfaces/dtos/bag-dto.ts
@@ -10,9 +10,10 @@ export interface BagDTO {
   id: string;
   status:
     | "PENDING"
+    | "VERIFIED"
+    | "MOUNTED"
     | "CANCELLED"
     | "RECEIVED"
-    | "SEPARATED"
     | "DISPATCHED"
     | "DEFERRED";
   paid: boolean;

--- a/shared/src/types/bag-status.ts
+++ b/shared/src/types/bag-status.ts
@@ -1,11 +1,11 @@
 export type BagStatus = {
   offer: "PENDING" | "CANCELLED" | "VERIFIED";
-  build: "PENDING" | "SEPARATED";
-  send: "SEPARATED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
+  build: "VERIFIED" | "MOUNTED";
+  send: "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
 };
 
 export type SendStatus = Array<
-  "SEPARATED" | "DISPATCHED" | "RECEIVED" | "DEFERRED"
+  "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED"
 >;
-export type BuildStatus = Array<"PENDING" | "SEPARATED">;
+export type BuildStatus = Array<"VERIFIED" | "MOUNTED">;
 export type OfferStatus = Array<"PENDING" | "CANCELLED" | "VERIFIED">;

--- a/shared/src/utils/convert-status.tsx
+++ b/shared/src/utils/convert-status.tsx
@@ -8,7 +8,7 @@ import { IoCloseSharp } from "react-icons/io5";
 export const convertStatus = (status: string) => {
   const statuses: Record<string, string> = {
     PENDING: "Pendente",
-    SEPARATED: "Separado",
+    MOUNTED: "Separado",
     DISPATCHED: "Enviado",
     RECEIVED: "Recebido",
     CANCELLED: "Cancelado",


### PR DESCRIPTION
Foram arrumados os status das bags para condizer com o backend. As mudanças foram as seguintes, não existe mais o status "SEPARATED", ele foi alterado por "MOUNTED". O fluxo se dá pelo seguinte:

* Receber Oferta: Quando terminamos de receber uma oferta e aceitamos todos os produtos, ele automaticamente coloca a sacola como "VERIFIED";

* Montar Sacola: Ao chegar do recebimento da oferta a sacola está como verificada e o próximo status que ela vai receber assim que for montada será "MOUNTED";

*Enviar Sacola: Quando a sacola chega para ser enviada, o status inicial dela, que antes era "SEPARATED" agora passa a ser o "MOUNTED".

O resto dos status permanecem inalterados, portanto foi feito o ajuste dessas pequenas mudanças.