### PR TITLE
feat: input description fix and empty description

### DIFF
--- a/producer/src/app/(protected)/oferta/adicionar/page.tsx
+++ b/producer/src/app/(protected)/oferta/adicionar/page.tsx
@@ -65,9 +65,12 @@ export default function Home() {
       amount:
       offer.product.pricing === "UNIT" ? offer.amount : offer.amount * 1000,
       price: offer.price,
-      description: offer.description ?? undefined,
       expires_at: formatDate(expiresAt),
     };
+
+    if (offer.description) {
+      offerPayload.description = offer.description;
+    }
 
     if (offer.comment) {
       offerPayload.comment = offer.comment;

--- a/producer/src/app/(protected)/oferta/components/InputDescription.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputDescription.tsx
@@ -73,7 +73,7 @@ export default function InputDescription({
           maxLength={100}
           value={description}
           onChange={handleChangeDescription}
-          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-28"
+          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-44"
           placeholder={`Escreva aqui as características do produto e demais informações que serão exibidas para o consumidor. 
 Ex.: Pote de geleia caseira de pimenta. Comercializado em um vidro de 400g. Produto artesanal e sem conservantes.`}
         />

--- a/producer/src/app/(protected)/oferta/components/InputDescription.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputDescription.tsx
@@ -35,12 +35,12 @@ export default function InputDescription({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (description.length > 200) {
+    if (description.length > 100) {
       toast.error("A descrição deve ter no máximo 200 caracteres.");
       return;
     }
 
-    if (comment.length > 200) {
+    if (comment.length > 100) {
       toast.error("O comentário deve ter no máximo 200 caracteres.");
       return;
     }
@@ -65,36 +65,37 @@ export default function InputDescription({
         </Button>
       }
     >
-      <div className="w-full h-full relative flex flex-col text-slate-gray pt-5">
+      <div className="w-full relative flex flex-col text-slate-gray pt-5">
         <label className="text-sm inter-font font-normal text-theme-primary pb-2">
           Descrição para o Consumidor
         </label>
         <textarea
-          maxLength={200}
+          maxLength={100}
           value={description}
           onChange={handleChangeDescription}
-          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-56"
+          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-28"
           placeholder={`Escreva aqui as características do produto e demais informações que serão exibidas para o consumidor. 
 Ex.: Pote de geleia caseira de pimenta. Comercializado em um vidro de 400g. Produto artesanal e sem conservantes.`}
         />
-        <p className="text-right text-slate-gray text-xs mt-1">{`${charCountDescription}/200`}
+        <p className="text-right text-slate-gray text-xs mt-1">{`${charCountDescription}/100`}
         </p>
       </div>
 
       <div className="w-full h-full relative flex flex-col text-slate-gray">
-        <label className="text-sm inter-font font-normal text-theme-primary pb-2">
+        <label className="text-sm inter-font font-normal text-theme-primary">
           Comentário para o time interno e-COO
         </label>
         <textarea
-          maxLength={200}
+          maxLength={100}
           value={comment}
           onChange={handleChangeComment}
-          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-36"
+          className="p-3 border border-theme-primary rounded-lg inter-font font-normal h-28"
           placeholder="Deixe aqui algum comentário para o time interno da e-COO. Ex.: Produto fornecido pelo produtor Fulano."
         />
-        <p className="text-right text-slate-gray text-xs mt-1">{`${charCountComment}/200`}
+        <p className="text-right text-slate-gray text-xs mt-1">{`${charCountComment}/100`}
         </p>
       </div>
+      
     </ModelPage>
   );
 }


### PR DESCRIPTION
Foi arrumado o tamanho dos campos de comentário e descrição para ser o tamanho certo levando em consideração o maior número de caractéres, que também foram alterados de 200 para 100. Além disso foi arrumado um bug que fazia com que quando o usuário digitava algo na descrição e apagava, esse campo era enviado vazio para o backend ocasionando um erro de validação.