### PR TITLE
Feat/recurrence modal

### DIFF
--- a/admin/src/app/(protected)/(sidebar)/pedidos/[bag_id]/page.tsx
+++ b/admin/src/app/(protected)/(sidebar)/pedidos/[bag_id]/page.tsx
@@ -180,7 +180,7 @@ const BagDetailsPage = () => {
                                 title={
                                   item.status === 'RECEIVED'
                                     ? 'Entregue'
-                                    : item.status === 'CANCELLED'
+                                    : item.status === 'REJECTED'
                                     ? 'Retornado'
                                     : 'Pendente'
                                 }
@@ -188,13 +188,13 @@ const BagDetailsPage = () => {
                                   ${
                                     item.status === 'RECEIVED'
                                       ? 'bg-green-500'
-                                      : item.status === 'CANCELLED'
+                                      : item.status === 'REJECTED'
                                       ? 'bg-red-500'
                                       : 'bg-gray-400'
                                   }`}
                               >
                                 {item.status === 'RECEIVED' && '✔'}
-                                {item.status === 'CANCELLED' && '✖'}
+                                {item.status === 'REJECTED' && '✖'}
                               </div>
                             </div>
                           ))}

--- a/cdd/src/app/(protected)/(footered)/ofertas/[box_id]/components/FarmOrdersTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/ofertas/[box_id]/components/FarmOrdersTable.tsx
@@ -56,7 +56,7 @@ export default function FarmOrdersTable() {
     await handleBox({
       box_id: box_id as string,
       order_id: order_id as string,
-      status: "CANCELLED",
+      status: "REJECTED",
       successMessage: "Oferta rejeitada com sucesso!",
     });
 

--- a/cdd/src/app/(protected)/(footered)/ofertas/components/FarmWithOrdersTable.tsx
+++ b/cdd/src/app/(protected)/(footered)/ofertas/components/FarmWithOrdersTable.tsx
@@ -27,9 +27,10 @@ type FilterStatus = {
 };
 
 const statuses: FilterStatus[] = [
-  { name: 'todas', key: ['PENDING', 'VERIFIED', 'CANCELLED'] },
+  { name: 'todas', key: ['PENDING', 'VERIFIED', 'REJECTED', 'CANCELLED'] },
   { name: 'pendentes', key: ['PENDING'] },
   { name: 'verificadas', key: ['VERIFIED'] },
+  { name: 'rejeitadas', key: ['REJECTED'] },
   { name: 'canceladas', key: ['CANCELLED'] },
 ];
 

--- a/cdd/src/app/_actions/orders/PATCH/handle-order.ts
+++ b/cdd/src/app/_actions/orders/PATCH/handle-order.ts
@@ -5,7 +5,7 @@ import ApiService from "@shared/service";
 export interface HandleBoxRequest {
   box_id: string;
   order_id: string;
-  status: "RECEIVED" | "CANCELLED";
+  status: "RECEIVED" | "REJECTED";
 }
 
 export async function handleOrder({

--- a/producer/src/app/(protected)/oferta/adicionar/page.tsx
+++ b/producer/src/app/(protected)/oferta/adicionar/page.tsx
@@ -143,7 +143,7 @@ export default function Home() {
             }
           />
         )}
-        {currentStep === 6 && (
+        {currentStep === 6 && offer.product.perishable === false && (
           <InputRecurrence
             handleNextStep={handleNextStep}
             setRecurrence={(recurring) =>
@@ -151,7 +151,7 @@ export default function Home() {
             }
           />
         )}
-        {currentStep === 7 && (
+        {currentStep === 6 && offer.product.perishable === true && (
           <ReviewOffer
             productId={offer.product.id ?? ""}
             productName={offer.product.name ?? ""}
@@ -161,7 +161,23 @@ export default function Home() {
             comment={offer.comment ?? ""}
             pricing={offer.product.pricing ?? "UNIT"}
             expires_at={offer.product.perishable ? undefined : offer.expires_at}
-            recurring={offer.recurring ?? ""}
+            recurring={offer.recurring ?? "false"}
+            closes_at={offer.closes_at}
+            submitAction={submitOffer}
+          />
+        )}
+        {currentStep === 7 && offer.product.perishable === false && (
+          <ReviewOffer
+            productId={offer.product.id ?? ""}
+            productName={offer.product.name ?? ""}
+            amount={offer.amount ?? 0}
+            price={offer.price ?? 0}
+            description={offer.description ?? ""}
+            comment={offer.comment ?? ""}
+            pricing={offer.product.pricing ?? "UNIT"}
+            expires_at={offer.product.perishable ? undefined : offer.expires_at}
+            recurring={offer.recurring ?? "false"}
+            closes_at={offer.closes_at}
             submitAction={submitOffer}
           />
         )}

--- a/producer/src/app/(protected)/oferta/components/InputRecurrence.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputRecurrence.tsx
@@ -1,10 +1,12 @@
 import { twMerge } from "tailwind-merge";
 import { toast } from "sonner";
 import { useEffect, useState } from "react";
+import React from "react";
 
 import Button from "@shared/components/Button";
 import SelectInput from "@shared/components/SelectInput";
 import { ModelPage } from "@shared/components/ModelPage";
+import InfoModal from "@shared/components/InfoModal";
 
 import pageSettings from "./page-settings";
 
@@ -23,7 +25,6 @@ function validateValue(value: string) {
   return true;
 }
 
-
 export default function InputRecurrence({
   handleNextStep,
   isRecurrent,
@@ -31,6 +32,8 @@ export default function InputRecurrence({
 }: InputAmountProps) {
   const { title, subtitle } = pageSettings.recurrence;
   const [recurrenceValue, setRecurrenceValue] = useState<string>("false");
+
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
 
   const optionsChange  = [
     { value: "false", label: "Não" },
@@ -49,17 +52,21 @@ export default function InputRecurrence({
     handleNextStep();
   };
 
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  }
+
   return (
     <ModelPage
       title={title}
-      titleGap="gap-5"
+      titleGap="gap-5 pr-4 pl-6"
       subtitleClassName="px-3"
       subtitle={subtitle}
       buttonArea={
         <Button
           className="w-full h-12 bg-theme-default rounded-md text-white font-semibold text-base leading-5.5"
           type="submit"
-          onClick={handleSubmit}
+          onClick={handleOpenModal}
           title="Continuar"
         >
           Continuar
@@ -85,6 +92,35 @@ export default function InputRecurrence({
           </div>
         </div>
       </div>
+      <InfoModal
+        titleContentModal="Atenção!"
+        contentModal={
+          <div className="text-center font-inter font-light text-slate-gray text-sm flex flex-col gap-7 p-5">
+            <div>
+              Ao ativar a oferta recorrente, esta se repetirá automaticamente em todos os ciclos seguintes, mantendo as mesmas informações de quantidade, preço e descrição da oferta original.
+            </div>
+            <div>
+              Para cancelar a sua oferta recorrente, exluca ela da sua lista de ofertas.
+            </div>
+          </div>
+        }
+        icon="!"
+        titleCloseModal="Ok, entendi"
+        isOpen={isModalOpen}
+        setIsOpen={setIsModalOpen}
+        buttonRequest={
+          <button
+            type="button"
+            className="w-full text-white justify-center rounded-md border border-transparent bg-rain-forest px-3 py-4 font-semibold h-12 flex items-center font-inter text-base leading-5.5 tracking-tight-2"
+            onClick={handleSubmit}
+          >
+            Ok, entendi
+          </button>
+        }
+        window_size="max-w-sm"
+        text_align="text-center"
+        text_size="text-lg font-inter font-light text-slate-gray"
+      />
     </ModelPage>
   );
 }

--- a/producer/src/app/(protected)/oferta/components/InputRecurrence.tsx
+++ b/producer/src/app/(protected)/oferta/components/InputRecurrence.tsx
@@ -100,7 +100,7 @@ export default function InputRecurrence({
               Ao ativar a oferta recorrente, esta se repetirá automaticamente em todos os ciclos seguintes, mantendo as mesmas informações de quantidade, preço e descrição da oferta original.
             </div>
             <div>
-              Para cancelar a sua oferta recorrente, exluca ela da sua lista de ofertas.
+              Para cancelar a sua oferta recorrente, exclua ela da sua lista de ofertas.
             </div>
           </div>
         }

--- a/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
+++ b/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
@@ -24,8 +24,6 @@ interface ReviewOfferProps {
 export default function ReviewOffer(props: ReviewOfferProps) {
   const { title, subtitle } = pageSettings.review;
 
-  console.log(props);
-
   const rows = [
     {
       header: "Produto:",

--- a/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
+++ b/producer/src/app/(protected)/oferta/components/ReviewOffer.tsx
@@ -17,11 +17,14 @@ interface ReviewOfferProps {
   submitAction: () => void;
   description?: string;
   comment?: string;
-  recurring: string;
+  closes_at: Date
+  recurring?: string;
 }
 
 export default function ReviewOffer(props: ReviewOfferProps) {
   const { title, subtitle } = pageSettings.review;
+
+  console.log(props);
 
   const rows = [
     {
@@ -55,8 +58,15 @@ export default function ReviewOffer(props: ReviewOfferProps) {
     },
     {
       header: "Recorrente?",
-      content: props.recurring === "true" ? "Sim" : "Não",
-    }
+      content:
+        props.recurring === "true"
+          ? "Sim"
+          : props.recurring === "false" 
+          ? "Não"
+          : props.closes_at
+          ? "Não"
+          : "Sim",
+    },
   ];
 
   return (

--- a/producer/src/app/(protected)/oferta/editar/page.tsx
+++ b/producer/src/app/(protected)/oferta/editar/page.tsx
@@ -38,6 +38,7 @@ export default function Home() {
     const storedOfferData = sessionStorage.getItem("edit-offer-data");
     if (storedOfferData) {
       const offerData: OfferDTO = JSON.parse(storedOfferData);
+      console.log("offerData", offerData);
       setOffer({
         ...offerData,
         amount: convertOfferAmount(offerData.amount, offerData.product.pricing),
@@ -192,7 +193,7 @@ export default function Home() {
                 comment={offer.comment ?? ""}
                 pricing={offer.product.pricing ?? "UNIT"}
                 expires_at={offer.product.perishable ? undefined : offer.expires_at}
-                recurring={offer.recurring ?? false}
+                closes_at={offer.closes_at}
                 submitAction={onUpdateOffer}
               />
             )}

--- a/producer/src/app/(protected)/oferta/repetir/page.tsx
+++ b/producer/src/app/(protected)/oferta/repetir/page.tsx
@@ -167,7 +167,6 @@ export default function Home() {
                 comment= {offer.comment ?? ""}
                 pricing={offer.product.pricing ?? "UNIT"}
                 expires_at={offer.product.perishable ? undefined : offer.expires_at}
-                recurring={offer.recurring ?? false}
                 closes_at={offer.closes_at}
                 submitAction={submitOffer}
               />

--- a/producer/src/app/(protected)/oferta/repetir/page.tsx
+++ b/producer/src/app/(protected)/oferta/repetir/page.tsx
@@ -168,6 +168,7 @@ export default function Home() {
                 pricing={offer.product.pricing ?? "UNIT"}
                 expires_at={offer.product.perishable ? undefined : offer.expires_at}
                 recurring={offer.recurring ?? false}
+                closes_at={offer.closes_at}
                 submitAction={submitOffer}
               />
             )}

--- a/producer/tailwind.config.ts
+++ b/producer/tailwind.config.ts
@@ -133,20 +133,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [
-    function ({ addUtilities }: { addUtilities: any }) {
-      const newUtilities = {
-        ".scrollbar-hide": {
-          "scrollbar-width": "none",
-          "-ms-overflow-style": "none",
-          "&::-webkit-scrollbar": {
-            display: "none",
-          },
-        },
-      };
-      addUtilities(newUtilities);
-    },
-  ],
 };
 
 export default config;

--- a/shared/src/components/InfoModal.tsx
+++ b/shared/src/components/InfoModal.tsx
@@ -6,7 +6,7 @@ interface InfoModalProps {
   contentModal: string | JSX.Element;
   icon: React.ReactNode | string;
   titleCloseModal: string;
-  buttonOpenModal: React.ReactNode;
+  buttonOpenModal?: React.ReactNode;
   buttonRequest?: React.ReactNode;
   isOpen: boolean;
   window_size?: string;

--- a/shared/src/hooks/useGetStatus.tsx
+++ b/shared/src/hooks/useGetStatus.tsx
@@ -15,7 +15,7 @@ export type EnviarStatus = Array<
 >;
 
 export type StatusMap = {
-  oferta: "PENDING" | "CANCELLED" | "VERIFIED";
+  oferta: "PENDING" | "CANCELLED" | "VERIFIED" | "REJECTED";
   montar: "VERIFIED" | "MOUNTED";
   enviar: "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
   farm: FarmStatus;
@@ -45,6 +45,10 @@ export function useGetStatus() {
         color: "bg-walnut-brown",
       },
       CANCELLED: {
+        content: <IoCloseSharp className="p-0.5" color="white" />,
+        color: "bg-error",
+      },
+      REJECTED: {
         content: <IoCloseSharp className="p-0.5" color="white" />,
         color: "bg-error",
       },

--- a/shared/src/interfaces/dtos/bag-dto.ts
+++ b/shared/src/interfaces/dtos/bag-dto.ts
@@ -13,6 +13,7 @@ export interface BagDTO {
     | "VERIFIED"
     | "MOUNTED"
     | "CANCELLED"
+    | "REJECTED"
     | "RECEIVED"
     | "DISPATCHED"
     | "DEFERRED";

--- a/shared/src/interfaces/dtos/box-dto.ts
+++ b/shared/src/interfaces/dtos/box-dto.ts
@@ -2,7 +2,7 @@ import { CatalogDTO, OrderDTO } from "@shared/interfaces/dtos";
 
 export interface BoxDTO {
   id: string;
-  status: "PENDING" | "CANCELLED" | "VERIFIED";
+  status: "PENDING" | "CANCELLED" | "VERIFIED" | "REJECTED";
   verified: number;
   catalog_id: string;
   catalog: CatalogDTO;

--- a/shared/src/interfaces/dtos/offer-dto.ts
+++ b/shared/src/interfaces/dtos/offer-dto.ts
@@ -16,4 +16,5 @@ export interface OfferDTO {
   updated_at: Date | null;
   expires_at: Date | undefined;
   recurring: string;
+  closes_at: Date;
 }

--- a/shared/src/interfaces/dtos/order-dto.ts
+++ b/shared/src/interfaces/dtos/order-dto.ts
@@ -2,7 +2,7 @@ import { OfferDTO } from "@shared/interfaces/dtos";
 
 export interface OrderDTO {
   id: string;
-  status: "PENDING" | "CANCELLED" | "RECEIVED";
+  status: "PENDING" | "CANCELLED" | "RECEIVED" | "REJECTED";
   amount: number;
   bag_id: string;
   box_id: string;

--- a/shared/src/types/bag-status.ts
+++ b/shared/src/types/bag-status.ts
@@ -1,5 +1,5 @@
 export type BagStatus = {
-  offer: "PENDING" | "CANCELLED" | "VERIFIED";
+  offer: "PENDING" | "CANCELLED" | "VERIFIED" | "REJECTED";
   build: "VERIFIED" | "MOUNTED";
   send: "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED";
 };
@@ -8,4 +8,4 @@ export type SendStatus = Array<
   "MOUNTED" | "DISPATCHED" | "RECEIVED" | "DEFERRED"
 >;
 export type BuildStatus = Array<"VERIFIED" | "MOUNTED">;
-export type OfferStatus = Array<"PENDING" | "CANCELLED" | "VERIFIED">;
+export type OfferStatus = Array<"PENDING" | "CANCELLED" | "VERIFIED" | "REJECTED">;

--- a/shared/src/utils/convert-status.tsx
+++ b/shared/src/utils/convert-status.tsx
@@ -21,6 +21,7 @@ export const convertStatus = (status: string) => {
   const colorStatus: Record<string, string> = {
     PENDING: "bg-battleship-gray",
     CANCELLED: "bg-error",
+    REJECTED: "bg-error",
     VERIFIED: "bg-rain-forest",
   };
 
@@ -30,6 +31,7 @@ export const convertStatus = (status: string) => {
     DISPATCHED: "text-rain-forest",
     RECEIVED: "text-rain-forest",
     CANCELLED: "text-error",
+    REJECTED: "text-error",
     DEFERRED: "text-rain-forest",
     VERIFIED: "text-rain-forest",
     ACTIVE: "text-rain-forest",
@@ -50,6 +52,7 @@ export const convertStatus = (status: string) => {
       >
         {status === 'VERIFIED' || status === "RECEIVED" && (<FaCheck color="white" />)}
         {status === "CANCELLED" && (<IoCloseSharp color="white" />)}
+        {status === "REJECTED" && (<IoCloseSharp color="white" />)}
         {status === "PENDING" && (<FaExclamation size={10} color="white" />)}
       </div>
     );


### PR DESCRIPTION
Card: [[Produtor] - Implementar no Fluxo de oferta a oferta recorrente.](https://app.clickup.com/t/86a9h7w3y)

Descrição: Nessa task foi finalizada o card acima, onde foi adicionado o modal de confirmação para ofertas recorrentes, bem como adicionado a feature em que uma oferta só poderá ser recorrente caso ela não seja perecível. Além disso, foi alterado um ponto trazido pelo Timóteo, onde o status passado quando uma oferta era recusada pelo CDD estava sendo enviado como "CANCELLED" ao invés de "REJECTED", foi alterado e corrigido.